### PR TITLE
Bugfix/issue 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nativescript-community/algolia",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "devDependencies": {
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",

--- a/src/algolia-index.android.d.ts
+++ b/src/algolia-index.android.d.ts
@@ -4,3 +4,7 @@ export declare class AlgoliaIndex {
     setSettings(settings: Object, handler: Function): void;
     addObjects(object: Object, handler: Function): void;
 }
+
+export declare class CompletionHandler {
+    handler: Function;
+}

--- a/src/algolia-index.android.ts
+++ b/src/algolia-index.android.ts
@@ -35,7 +35,7 @@ export class AlgoliaIndex {
     }
 }
 
-const CompletionHandler = com.algolia.search.saas.CompletionHandler.extend({
+export const CompletionHandler = com.algolia.search.saas.CompletionHandler.extend({
     init(): void {
         return global.__native(this);
     },
@@ -48,5 +48,3 @@ const CompletionHandler = com.algolia.search.saas.CompletionHandler.extend({
         return this.handler(JSON.parse(content.toString()));
     }
 });
-
-exports.CompletionHandler = CompletionHandler;


### PR DESCRIPTION
## Summary

This PR fixes the export for CompletionHandler in algolia-index

## Previous behaviour

Building with webpack gives this warning

```
WARNING in ./node_modules/@nativescript-community/algolia/algolia.android.js 12:38-55
export 'CompletionHandler' (imported as 'CompletionHandler') was not found in './algolia-index' (possible exports: AlgoliaIndex)
 @ ./app/pages/findRecipes/findRecipes-page.js 5:0-58 142:26-33
 @ ./app/ sync .(xml|js|s?css)$ ./pages/findRecipes/findRecipes-page.js
 @ ./app/__@nativescript_webpack_virtual_entry_javascript__ 3:16-89
```

## New behavior

The warning won't show up anymore.